### PR TITLE
Fixes for CUR/ICO and ImageSharp 4.0 alpha

### DIFF
--- a/example/Program.cs
+++ b/example/Program.cs
@@ -191,7 +191,7 @@ static void PrintUsage()
     Console.WriteLine("Encoding usage: SixPix.exe [/t|/T] <filein> [<fileout>]");
     Console.WriteLine(" /t              : make color at top-left (0,0) transparent");
     Console.WriteLine(" /T              : make GIF or WebP background color transparent");
-#if IMAGESHARP4
+#if IMAGESHARP4 // ImageSharp v4.0 adds support for CUR and ICO files
     Console.WriteLine(" <filein>        : Image file to encode to Sixel, supports BMP, CUR, GIF, ICO,");
     Console.WriteLine("                   JPEG, PBM, PNG, QOI, TGA, TIFF, and WebP");
 #else

--- a/example/Program.cs
+++ b/example/Program.cs
@@ -13,10 +13,9 @@ if (args.Length == 0)
     Environment.Exit(1);
 }
 
-bool transp_bg = false;
-bool transp_tl = false;
-string infile = "";
-string outfile = "";
+bool transp_bg = false, transp_tl = false;
+int w = -1, h = -1;
+string infile = "", outfile = "";
 const string MAP8_SIXEL = "Pq\"1;0;93;14#0;2;60;0;0#1;2;0;66;0#2;2;56;60;0#3;2;47;38;97#4;2;72;0;69#5;2;0;66;72#6;2;72;72;72#7;2;0;0;0#0!11~#1!12~#2!12~#3!12~#4!12~#5!12~#6!12~#7!10~-#0!11~#1!12~#2!12~#3!12~#4!12~#5!12~#6!12~#7!10~-#0!11B#1!12B#2!12B#3!12B#4!12B#5!12B#6!12B#7!10B\\";
 
 foreach (var arg in args)
@@ -25,23 +24,46 @@ foreach (var arg in args)
     if (arg.StartsWith('-') || arg.StartsWith('/'))
     {
         param = arg.TrimStart('-', '/');
-        if (param.StartsWith('t'))
-            transp_bg = true;
-        else if (param.StartsWith('T'))
-            transp_tl = true;
-        else if (param.StartsWith('o'))
+        switch (param[0])
         {
-            if (param.Contains('='))
-                outfile = param[param.IndexOf('=')..];
-            else if (param.Contains(':'))
-                outfile = param[param.IndexOf(':')..];
-        }
-        else if (param.StartsWith('i'))
-        {
-            if (param.Contains('='))
-                infile = param[param.IndexOf('=')..];
-            else if (param.Contains(':'))
-                infile = param[param.IndexOf(':')..];
+            case 't':
+                transp_bg = true;
+                break;
+            case 'T':
+                transp_tl = true;
+                break;
+            case 'w':
+            case 'W':
+                if (param.Contains('='))
+                    _ = int.TryParse(param[(param.IndexOf('=') + 1)..], out w);
+                else if (param.Contains(':'))
+                    _ = int.TryParse(param[(param.IndexOf(':') + 1)..], out w);
+                break;
+            case 'h':
+            case 'H':
+                if (param.Contains('='))
+                    _ = int.TryParse(param[(param.IndexOf('=') + 1)..], out h);
+                else if (param.Contains(':'))
+                    _ = int.TryParse(param[(param.IndexOf(':') + 1)..], out h);
+                break;
+            case 'o':
+            case 'O':
+                if (param.Contains('='))
+                    outfile = param[(param.IndexOf('=') + 1)..];
+                else if (param.Contains(':'))
+                    outfile = param[(param.IndexOf(':') + 1)..];
+                break;
+            case 'i':
+            case 'I':
+                if (param.Contains('='))
+                    infile = param[(param.IndexOf('=') + 1)..];
+                else if (param.Contains(':'))
+                    infile = param[(param.IndexOf(':') + 1)..];
+                break;
+            default:
+                Console.Error.WriteLine("Error: Unrecognized parameter '" + param + "'");
+                Environment.Exit(1);
+                break;
         }
     }
     else if (string.IsNullOrEmpty(infile))
@@ -63,26 +85,16 @@ var fileInfo = new FileInfo(infile);
 if (IsBinary(infile))
 {
     var start = DateTime.Now;
-    Color? bg = null;
-    Color? tc = null;
 
     try
     {
         using var fs = fileInfo.OpenRead();
         using var image = Image.Load(fs);
-        var meta = image.Metadata;
-
-        if (fileInfo.Extension == ".gif")
-            bg = meta.GetGifMetadata()?.GlobalColorTable?.Span[meta.GetGifMetadata().BackgroundColorIndex];
-        else if (fileInfo.Extension == ".webp" || fileInfo.Extension == ".web")
-            bg = meta.GetWebpMetadata()?.BackgroundColor;
-        else if (fileInfo.Extension == ".png")
-            tc = meta.GetPngMetadata()?.TransparentColor; // Only applies to PngColorType.Palette
 
         fs.Seek(0, 0);
 
         // Encode: Image stream -> Sixel string (ReadOnlySpan<char>)
-        var sixelString = Sixel.Encode(fs, bg, tc, transp_bg, transp_tl);
+        var sixelString = Sixel.Encode(fs, new Size(w, h), transp_bg, transp_tl);
 #if DEBUG
         var elapsed = DateTime.Now - start;
         Console.WriteLine($"Elapsed {elapsed.TotalMilliseconds} ms");
@@ -188,20 +200,28 @@ static void PrintUsage()
     Console.WriteLine(MAP8_SIXEL);
     Console.WriteLine("[If you see colored bands above, your terminal supports Sixel!]");
     Console.WriteLine();
-    Console.WriteLine("Encoding usage: SixPix.exe [/t|/T] <filein> [<fileout>]");
-    Console.WriteLine(" /t              : make color at top-left (0,0) transparent");
-    Console.WriteLine(" /T              : make GIF or WebP background color transparent");
 #if IMAGESHARP4 // ImageSharp v4.0 adds support for CUR and ICO files
-    Console.WriteLine(" <filein>        : Image file to encode to Sixel, supports BMP, CUR, GIF, ICO,");
-    Console.WriteLine("                   JPEG, PBM, PNG, QOI, TGA, TIFF, and WebP");
+    Console.WriteLine("Encoding usage:");
+    Console.WriteLine("     SixPix.exe [/t|/T] [/w:<width>] [/h:height>] <filein> [<fileout>]");
 #else
-    Console.WriteLine(" <filein>        : Image file to encode to Sixel, supports BMP, GIF, JPEG, PBM,");
-    Console.WriteLine("                   PNG, QOI, TGA, TIFF, and WebP");
+    Console.WriteLine("Encoding usage: SixPix.exe [/t|/T] <filein> [<fileout>]");
+#endif
+    Console.WriteLine(" /t              : make color at top-left (0,0) transparent (optional)");
+    Console.WriteLine(" /T              : make GIF or WebP background color transparent (optional)");
+#if IMAGESHARP4 // ImageSharp v4.0 adds support for CUR and ICO files
+    Console.WriteLine(" /w:<width>      : Width in pixels (optional)");
+    Console.WriteLine(" /h:<height>     : Height in pixels (optional)");
+    Console.WriteLine(" <filein>        : Image file to encode to Sixel (required), supports BMP, CUR,");
+    Console.WriteLine("                   GIF, ICO, JPEG, PBM, PNG, QOI, TGA, TIFF, and WebP");
+#else
+    Console.WriteLine(" <filein>        : Image file to encode to Sixel (required), supports BMP, GIF,");
+    Console.WriteLine("                   JPEG, PBM, PNG, QOI, TGA, TIFF, and WebP");
 #endif
     Console.WriteLine(" <fileout>[.six] : Output Sixel text filename (optional)");
     Console.WriteLine();
-    Console.WriteLine("Decoding usage: SixPix.exe <filein> <fileout>");
-    Console.WriteLine(" <filein>        : Sixel text file to decode");
-    Console.WriteLine(" <fileout>[.png] : Output PNG image filename");
+    Console.WriteLine("Decoding usage:");
+    Console.WriteLine("     SixPix.exe <filein> <fileout>");
+    Console.WriteLine(" <filein>        : Sixel text file to decode (required)");
+    Console.WriteLine(" <fileout>[.png] : Output PNG image filename (required)");
     Console.WriteLine();
 }

--- a/example/example.csproj
+++ b/example/example.csproj
@@ -9,6 +9,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!--<DefineConstants>$(DefineConstants);IMAGESHARP4</DefineConstants>-->
   </PropertyGroup>
 
 </Project>

--- a/src/SixPix.csproj
+++ b/src/SixPix.csproj
@@ -13,10 +13,15 @@
     <Copyright>Copyright (c) teramako 2024</Copyright>
     <RepositoryUrl>https://github.com/teramako/SixPix.NET</RepositoryUrl>
     <PackageTags>Sixel</PackageTags>
+    <!--<DefineConstants>$(DefineConstants);IMAGESHARP4</DefineConstants>-->
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+    <!--<PackageReference Include="SixLabors.ImageSharp" Version="4.0.0-alpha.0.18" />-->
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="../LICENSE" Pack="true" PackagePath="" />
     <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>

--- a/src/Sixel.Decode.cs
+++ b/src/Sixel.Decode.cs
@@ -65,7 +65,7 @@ public partial class Sixel
                 break;
         }
 
-        var campusSize = new Size(200, 200);
+        var canvasSize = new Size(200, 200);
         var resizeOption = new ResizeOptions()
         {
             Mode = ResizeMode.BoxPad,
@@ -73,9 +73,9 @@ public partial class Sixel
         };
 
 #if IMAGESHARP4 // ImageSharp v4.0
-        var image = new Image<Rgba32>(new Configuration(), campusSize.Width, campusSize.Height, Rgba32.FromScaledVector4(Color.White.ToScaledVector4()));
+        var image = new Image<Rgba32>(new Configuration(), canvasSize.Width, canvasSize.Height, Rgba32.FromScaledVector4(Color.White.ToScaledVector4()));
 #else
-        var image = new Image<Rgba32>(campusSize.Width, campusSize.Height, Color.White);
+        var image = new Image<Rgba32>(canvasSize.Width, canvasSize.Height, Color.White);
 #endif
 
 
@@ -118,10 +118,10 @@ public partial class Sixel
                     if (param.Count < 4)
                         throw new InvalidDataException($"Invalid Header: {string.Join(';', param)}");
 
-                    campusSize.Width = param[2];
-                    campusSize.Height = param[3];
-                    DebugPrint($"Resize Image {image.Size} => {campusSize}", lf: true);
-                    resizeOption.Size = campusSize;
+                    canvasSize.Width = param[2];
+                    canvasSize.Height = param[3];
+                    DebugPrint($"Resize Image {image.Size} => {canvasSize}", lf: true);
+                    resizeOption.Size = canvasSize;
                     image.Mutate(x => x.Resize(resizeOption));
                     continue;
                 case 0x23: // '#'
@@ -157,22 +157,22 @@ public partial class Sixel
                 case 0x2d: // '-'
                     currentX = 0;
                     currentY += 6;
-                    if (campusSize.Height < currentY + 6)
+                    if (canvasSize.Height < currentY + 6)
                     {
-                        campusSize.Height *= 2;
-                        DebugPrint($"Resize Image Height {image.Size} => {campusSize}", lf: true);
-                        resizeOption.Size = campusSize;
+                        canvasSize.Height *= 2;
+                        DebugPrint($"Resize Image Height {image.Size} => {canvasSize}", lf: true);
+                        resizeOption.Size = canvasSize;
                         image.Mutate(x => x.Resize(resizeOption));
                     }
                     break;
                 case > 0x3E and < 0x7F:
                     sixelBit = currentChar - 0x3F;
 
-                    if (campusSize.Width < currentX + repeatCount)
+                    if (canvasSize.Width < currentX + repeatCount)
                     {
-                        campusSize.Width *= 2;
-                        DebugPrint($"Resize Image Width {image.Size} => {campusSize}", lf: true);
-                        resizeOption.Size = campusSize;
+                        canvasSize.Width *= 2;
+                        DebugPrint($"Resize Image Width {image.Size} => {canvasSize}", lf: true);
+                        resizeOption.Size = canvasSize;
                         image.Mutate(x => x.Resize(resizeOption));
                     }
                     for (var x = currentX; x < currentX + repeatCount; x++)

--- a/src/Sixel.Decode.cs
+++ b/src/Sixel.Decode.cs
@@ -73,7 +73,7 @@ public partial class Sixel
         };
 
 #if IMAGESHARP4 // ImageSharp v4.0
-        var image = new Image<Rgba32>(new Configuration(), campusSize.Width, campusSize.Height, Rgb24.FromScaledVector4(Color.White.ToScaledVector4()));
+        var image = new Image<Rgba32>(new Configuration(), campusSize.Width, campusSize.Height, Rgba32.FromScaledVector4(Color.White.ToScaledVector4()));
 #else
         var image = new Image<Rgba32>(campusSize.Width, campusSize.Height, Color.White);
 #endif

--- a/src/Sixel.Encode.cs
+++ b/src/Sixel.Encode.cs
@@ -3,6 +3,8 @@ using System.Numerics;
 #endif
 using System.Text;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 
@@ -21,43 +23,83 @@ public partial class Sixel
     /// Encode Image stream to Sixel string
     /// </summary>
     /// <param name="stream">Image stream</param>
-    /// <param name="tc">Transparent color (for palette-based PNG images), or null</param>
-    /// <param name="bg">Background color (for some GIF or WebP images), or null</param>
+    /// <param name="size">Image size (for scaling), or null</param>
     /// <param name="transp_bg">Make the background color transparent (for some GIF or WebP images)</param>
     /// <param name="transp_tl">Make the color found at the top left corner (0, 0) transparent</param>
     /// <returns>Sixel string</returns>
-    public static ReadOnlySpan<char> Encode(Stream stream, Color? tc = null, Color? bg = null, bool transp_bg = false, bool transp_tl = false)
+    public static ReadOnlySpan<char> Encode(Stream stream, Size? size = null, bool transp_bg = false, bool transp_tl = false)
     {
-        using var img = Image.Load<Rgba32>(stream);
-        return Encode(img, tc, bg, transp_bg, transp_tl);
+        DecoderOptions opt = new();
+        if (size?.Width > 0 && size?.Height > 0)
+        {
+            opt = new()
+            {
+                TargetSize = new(size?.Width ?? 1, size?.Height ?? 1),
+            };
+        }
+        using var img = Image.Load<Rgba32>(opt, stream);
+        return Encode(img, size, transp_bg, transp_tl);
     }
     /// <summary>
     /// Encode Image to Sixel string
     /// </summary>
     /// <param name="img">Image data</param>
-    /// <param name="tc">Transparent color (for palette-based PNG images)</param>
-    /// <param name="bg">Background color (for some GIF or WebP images)</param>
+    /// <param name="size">Image size (for scaling), or null</param>
     /// <param name="transp_bg">Make the background color transparent (for some GIF or WebP images)</param>
     /// <param name="transp_tl">Make the color found at the top left corner (0, 0) transparent</param>
     /// <returns>Sixel string</returns>
-    public static ReadOnlySpan<char> Encode(Image<Rgba32> img, Color? tc = null, Color? bg = null, bool transp_bg = false, bool transp_tl = false)
+    public static ReadOnlySpan<char> Encode(Image<Rgba32> img, Size? size = null, bool transp_bg = false, bool transp_tl = false)
     {
+        int canvasWidth = -1, canvasHeight = -1;
+        if (size?.Width < 1 && size?.Height > 0)
+        {
+            // Keep aspect ratio
+            canvasHeight = size?.Height ?? 1;
+            canvasWidth = (canvasHeight * img.Width) / img.Height;
+        }
+        else if (size?.Height < 1 && size?.Width > 0)
+        {
+            // Keep aspect ratio
+            canvasWidth = size?.Width ?? 1;
+            canvasHeight = (canvasWidth * img.Height) / img.Width;
+        }
+
+        // TODO: Use maximum size based on size of terminal window?
+        if (canvasWidth < 1)
+            canvasWidth = img.Width;
+        if (canvasHeight < 1)
+            canvasHeight = img.Height;
+
+        var meta = img.Metadata;
+        Color? bg = null, tc = null;
+
+        if (meta.DecodedImageFormat?.Name == "GIF")
+            bg = meta.GetGifMetadata()?.GlobalColorTable?.Span[meta.GetGifMetadata().BackgroundColorIndex];
+        else if (meta.DecodedImageFormat?.Name == "WEBP")
+            bg = meta.GetWebpMetadata()?.BackgroundColor;
+        else if (meta.GetPngMetadata()?.ColorType == PngColorType.Palette &&
+            meta.DecodedImageFormat?.Name == "PNG")
+            tc = meta.GetPngMetadata()?.TransparentColor;
 #if IMAGESHARP4 // ImageSharp v4.0 adds support for CUR and ICO files
-        if ((img.Metadata.DecodedImageFormat?.Name == "CUR" ||
-            img.Metadata.DecodedImageFormat?.Name == "ICO") &&
+        if ((meta.DecodedImageFormat?.Name == "CUR" ||
+            meta.DecodedImageFormat?.Name == "ICO") &&
             img.Frames.Count > 0)
-            img = img.Frames.ExportFrame(GetBestIconFrame(img));
+            img = img.Frames.ExportFrame(GetBestIconFrame(img, new(canvasWidth, canvasHeight)));
 #endif
+
+        DebugPrint($"Width: {canvasWidth}, Height: {canvasHeight}, (bpp={img.PixelType.BitsPerPixel})", lf: true);
+        if (canvasWidth > 1 && canvasHeight > 1 && img.Width != canvasWidth && img.Height != canvasHeight)
+        {
+            img.Mutate(x => x.Resize(canvasWidth, canvasHeight));
+        }
 
         // 減色処理
         // Color Reduction
-        img.Mutate(x => {
+        img.Mutate(x =>
+        {
             x.Quantize(KnownQuantizers.Wu);
         });
-        var width = img.Width;
-        var height = img.Height;
 
-        DebugPrint($"Width: {width}, Height: {height}, (bpp={img.PixelType.BitsPerPixel})", lf: true);
         if (tc is not null)
             DebugPrint($"Transparent Palette Color={tc?.ToHex()}", lf: true);
         else if (bg is not null)
@@ -76,7 +118,7 @@ public partial class Sixel
         var sb = new StringBuilder();
         // DECSIXEL Introducer(\033P0;0;8q) + DECGRA ("1;1): Set Raster Attributes
         sb.Append(ESC + SixelStart)
-          .Append($";{width};{height}");
+          .Append($";{canvasWidth};{canvasHeight}");
 
         DebugPrint($"Palette Start Length={colorPalette.Length}", lf: true);
 
@@ -109,11 +151,11 @@ public partial class Sixel
         }
         DebugPrint("End Palette", ConsoleColor.DarkGray, true);
 
-        var buffer = new byte[width * colorPaletteLength];
+        var buffer = new byte[canvasWidth * colorPaletteLength];
         var cset = new bool[colorPaletteLength]; // 表示すべきカラーパレットがあるかのフラグ
                                                  // Flag to indicate whether there is a color palette to display
         var ch0 = specialChNr;
-        for (var (z, y) = (0, 0); z < (height + 5) / 6; z++, y = z * 6)
+        for (var (z, y) = (0, 0); z < (canvasHeight + 5) / 6; z++, y = z * 6)
         {
             if (z > 0) {
                 // DECGNL (-): Graphics Next Line
@@ -121,9 +163,9 @@ public partial class Sixel
                 DebugPrint("-", lf: true);
             }
             DebugPrint($"[{z}]", ConsoleColor.DarkGray);
-            for (var p = 0; p < 6 && y < height; p++, y++)
+            for (var p = 0; p < 6 && y < canvasHeight; p++, y++)
             {
-                for (var x = 0; x < width; x++)
+                for (var x = 0; x < canvasWidth; x++)
                 {
                     var idx = colorPalette.IndexOf(img[x, y]);
                     if (colorPalette[idx].A == 0)
@@ -135,7 +177,7 @@ public partial class Sixel
                     else
                         cset[idx] = true;
 
-                    buffer[width * idx + x] |= (byte)(1 << p);
+                    buffer[canvasWidth * idx + x] |= (byte)(1 << p);
                 }
             }
             bool first = true;
@@ -158,10 +200,10 @@ public partial class Sixel
                 byte ch;
                 int bufIndex;
                 char sixelChar;
-                for (var x = 0; x < width; x++)
+                for (var x = 0; x < canvasWidth; x++)
                 {
                     // make sixel character from 6 pixels
-                    bufIndex = width * n + x;
+                    bufIndex = canvasWidth * n + x;
                     ch = buffer[bufIndex];
                     buffer[bufIndex] = 0;
                     if (ch0 < 0x40 && ch != ch0)
@@ -240,9 +282,14 @@ public partial class Sixel
     }
 
 #if IMAGESHARP4 // ImageSharp v4.0 adds support for CUR and ICO files
-    static int GetBestIconFrame(Image icon)
+    static int GetBestIconFrame(Image<Rgba32> icon, Size? size)
     {
-        int bestFrame = 0, maxWidth = 0, maxBpp = 0, i = 0;
+        int? sizeDim;
+        int bestFrame = 0, bestDim = 0, maxBpp = 0, i = 0;
+        if (size?.Width > size?.Height)
+            sizeDim = size?.Width;
+        else
+            sizeDim = size?.Height;
         DebugPrint(icon.Frames.Count + " ImageFrames:", lf: true);
         foreach (var frame in icon.Frames)
         {
@@ -251,19 +298,22 @@ public partial class Sixel
             if ((int)meta.BmpBitsPerPixel >= maxBpp)
             {
                 maxBpp = (int)meta.BmpBitsPerPixel;
-                if (meta.EncodingWidth == 0) // oddly, 0 means 256
+                int w = meta.EncodingWidth;
+                //int h = meta.EncodingHeight;
+                if (w == 0) // oddly, 0 means 256
+                    w = 256;
+                if ((bestDim <= 0) ||
+                    ((sizeDim is null || sizeDim <= 0) && w > bestDim) ||
+                    (sizeDim is not null && sizeDim > 0 && w >= sizeDim && w < bestDim) ||
+                    (w > bestDim))
                 {
-                    maxWidth = 256;
-                    bestFrame = i;
-                }
-                else if (meta.EncodingWidth > maxWidth)
-                {
-                    maxWidth = meta.EncodingWidth;
+                    bestDim = w;
                     bestFrame = i;
                 }
             }
             i++;
         }
+        DebugPrint("Best frame:" + bestFrame, lf: true);
         return bestFrame;
     }
 #endif

--- a/src/Sixel.Encode.cs
+++ b/src/Sixel.Encode.cs
@@ -83,7 +83,7 @@ public partial class Sixel
 #if IMAGESHARP4 // ImageSharp v4.0 adds support for CUR and ICO files
         if ((meta.DecodedImageFormat?.Name == "CUR" ||
             meta.DecodedImageFormat?.Name == "ICO") &&
-            img.Frames.Count > 0)
+            img.Frames.Count > 1)
             img = img.Frames.ExportFrame(GetBestIconFrame(img, new(canvasWidth, canvasHeight)));
 #endif
 

--- a/src/Sixel.Encode.cs
+++ b/src/Sixel.Encode.cs
@@ -63,6 +63,11 @@ public partial class Sixel
             canvasWidth = size?.Width ?? 1;
             canvasHeight = (canvasWidth * img.Height) / img.Width;
         }
+        else if (size?.Height > 0 && size?.Width > 0)
+        {
+            canvasWidth = size?.Width ?? 1;
+            canvasHeight = size?.Height ?? 1;
+        }
 
         // TODO: Use maximum size based on size of terminal window?
         if (canvasWidth < 1)


### PR DESCRIPTION
ImageSharp v3.1.7 is still default, but if v4 alpha is used, I needed a way for the ICO/CUR decoder to pick the best frame.  This implementation just looks for the largest bpp with the largest size, but perhaps a preferred size and bpp could be specified.

That being said, however, my previous check-in has already made the number of Encode() parameters unwieldy, so if preferred size/bpp were to be added, I think a new "Options" class would be in order.  On the other hand, this seems like something that ImageSharp should have a way of handling...

EDIT: I wasn't familiar with ImageSharp before this, and I'm still learning... but I figured out how to determine which encoder was being used, so I could remove the background and palette transparent color parameters and move their discovery into the Encode() function.  Then I added an optional Size parameter that can resize the output, as well as a smarter way to determine the best frame of an ICO/CUR to use.