### PR TITLE
Improve animation and fix bugs

### DIFF
--- a/example/Program.cs
+++ b/example/Program.cs
@@ -206,7 +206,7 @@ if (IsBinary(infile))
 #endif
             if (f < 0)
                 f = 0;
-            Console.Write(sixelEncoder.EncodeFrame(f));
+            Console.WriteLine(sixelEncoder.EncodeFrame(f));
             Environment.Exit(0);
         }
 

--- a/example/Program.cs
+++ b/example/Program.cs
@@ -15,7 +15,7 @@ if (args.Length == 0)
 }
 
 Transparency transp = Transparency.Default;
-int w = -1, h = -1, f = -1, rate = 0;
+int w = -1, h = -1, f = -1, delay = -1;
 bool getData = false, anim = false, animForever = false;
 string infile = "", outfile = "";
 const string MAP8_SIXEL = "Pq\"1;1;93;14#0;2;60;0;0#1;2;0;66;0#2;2;56;60;0#3;2;47;38;97#4;2;72;0;69#5;2;0;66;72#6;2;72;72;72#7;2;0;0;0#0!11~#1!12~#2!12~#3!12~#4!12~#5!12~#6!12~#7!10~-#0!11~#1!12~#2!12~#3!12~#4!12~#5!12~#6!12~#7!10~-#0!11B#1!12B#2!12B#3!12B#4!12B#5!12B#6!12B#7!10B\\";
@@ -35,8 +35,8 @@ foreach (var arg in args)
                 anim = true;
                 animForever = true;
                 break;
-            case 'd':
-            case 'D':
+            case 'g':
+            case 'G':
                 getData = true;
                 break;
             case 't':
@@ -72,14 +72,12 @@ foreach (var arg in args)
                 if (f < 0)
                     f = 0;
                 break;
-            case 'r':
-            case 'R':
+            case 'd':
+            case 'D':
                 if (param.Contains('='))
-                    _ = int.TryParse(param[(param.IndexOf('=') + 1)..], out rate);
+                    _ = int.TryParse(param[(param.IndexOf('=') + 1)..], out delay);
                 else if (param.Contains(':'))
-                    _ = int.TryParse(param[(param.IndexOf(':') + 1)..], out rate);
-                if (rate < 0)
-                    rate = 0;
+                    _ = int.TryParse(param[(param.IndexOf(':') + 1)..], out delay);
                 break;
             case 'o':    // output filename (explicit instead of based on position)
             case 'O':
@@ -155,12 +153,20 @@ if (IsBinary(infile))
 #endif
         if (getData)
         {
+            (var cw, var ch) = sixelEncoder.CanvasSize;
             Console.WriteLine("Image Format: " + sixelEncoder.Format);
+            Console.WriteLine("  Image Size: " + cw + "x" + ch);
             Console.WriteLine("  Num Frames: " + sixelEncoder.FrameCount);
 #if IMAGESHARP4
             Console.WriteLine("  Best Frame: " + best);
 #endif
             Console.WriteLine(" Num Repeats: " + sixelEncoder.RepeatCount);
+                Console.Write("Frame Delays: [ ");
+            for (var fr = 0; fr < sixelEncoder.FrameCount; fr++)
+            {
+                Console.Write(sixelEncoder.GetFrameDelay(fr) + " ");
+            }
+            Console.WriteLine("]");
             Environment.Exit(sixelEncoder.FrameCount);
         }
 
@@ -222,7 +228,7 @@ if (IsBinary(infile))
         // Start animation
         Console.WriteLine("Press 'Ctrl+C', 'c' or 'q' to stop.");
         using var ct = new CancellationTokenSource();
-        sixelEncoder.SetFrameDelays(rate > 0 ? rate : 0);
+        sixelEncoder.SetFrameDelays(delay >= 0 ? delay : -1);
         var t1 = sixelEncoder.Animate(animForever ? 0 : 1,
                                       f < 0 ? 0 : f,
                                       -1,
@@ -347,7 +353,7 @@ static void PrintUsage()
     //----------------|---------10--------20--------30--------40--------50--------60--------70--------80
     //----------------|123456789|123456789|123456789|123456789|123456789|123456789|123456789|123456789|
     Console.WriteLine("Encoding usage:");
-    Console.WriteLine("     SixPix.exe [/t|/T|/b] [/w:<W>] [/h:<H>] [/a|/A|/f:<F>] [/r:R] <in> [<out>]");
+    Console.WriteLine("    SixPix.exe [/t|/T|/b] [/w:<W>] [/h:<H>] [/a|/A|/f:<F>] [/d:<D>] <in> [<out>]");
     Console.WriteLine(" /t          : Disable transparency, or enable when animating (optional)");
     Console.WriteLine(" /T          : Make color at top-left (x=0,y=0) transparent (optional)");
     Console.WriteLine(" /b          : Make GIF or WebP background color transparent (optional)");
@@ -355,10 +361,9 @@ static void PrintUsage()
     Console.WriteLine(" /h:<Height> : Height in pixels (optional)");
     Console.WriteLine(" /a          : Animate the frames of a multi-frame image (optional),");
     Console.WriteLine("               With <out> specified, encode all frames and append frame number");
-    Console.WriteLine(" /A          : Animate forever, 'Ctrl+C', 'c' or 'q' to stop (optional)");
+    Console.WriteLine(" /A          : Animate forever (optional), 'Ctrl+C', 'c' or 'q' to stop");
     Console.WriteLine(" /f:<Frame>  : Display a single frame of a multi-frame image (optional)");
-    Console.WriteLine(" /r:<Rate>   : Animation framerate (in frames per millisecond)");
-    Console.WriteLine("               0 or not specified means use the image's framerate");
+    Console.WriteLine(" /d:<Delay>  : Animation delay (in milliseconds)");
 #if IMAGESHARP4 // ImageSharp v4.0 adds support for CUR and ICO files
     Console.WriteLine(" <in>        : Image filename to encode to Sixel (required), supports BMP, CUR,");
     Console.WriteLine("               GIF, ICO, JPEG, PBM, PNG, QOI, TGA, TIFF, and WebP");
@@ -366,16 +371,16 @@ static void PrintUsage()
     Console.WriteLine(" <in>        : Image filename to encode to Sixel (required), supports BMP, GIF,");
     Console.WriteLine("               JPEG, PBM, PNG, QOI, TGA, TIFF, and WebP");
 #endif
-    Console.WriteLine(" <out>[.six] : Output Sixel text filename (optional)");
+    Console.WriteLine(" <out>[.six] : Output Sixel text filename (optional), otherwise display image(s)");
     Console.WriteLine();
     Console.WriteLine("Decoding usage:");
-    Console.WriteLine("     SixPix.exe <in> <out>");
+    Console.WriteLine("    SixPix.exe <in> <out>");
     Console.WriteLine(" <in>        : Sixel text file to decode (required)");
     Console.WriteLine(" <out>[.png] : Output PNG image filename (required)");
     Console.WriteLine();
     Console.WriteLine("Informational usage:");
-    Console.WriteLine("     SixPix.exe /d <in>");
-    Console.WriteLine(" /d          : Get image data (required), return code is number of frames");
+    Console.WriteLine("    SixPix.exe /g <in>");
+    Console.WriteLine(" /g          : Get image data (required), return code is number of frames");
     Console.WriteLine(" <in>        : Image filename to read (required)");
     Console.WriteLine();
 }

--- a/example/Program.cs
+++ b/example/Program.cs
@@ -109,9 +109,6 @@ foreach (var arg in args)
     // Don't allow file output forever
     if (!string.IsNullOrEmpty(outfile))
         animForever = false;
-    // Reverse /t logic when displaying animations
-    else if (anim && transp == Transparency.None)
-        transp = Transparency.Default;
 }
 if (!Path.Exists(infile))
 {
@@ -134,7 +131,19 @@ if (IsBinary(infile))
         using var image = Image.Load<Rgba32>(fs);
         using var sixelEncoder = Sixel.CreateEncoder(image)
                                       .Resize(width: w, height: h);
+
+        // Reverse /t logic when displaying animations
+        if (anim)
+        {
+            if (transp == Transparency.None)
+                transp = Transparency.Default;
+            else if (transp == Transparency.Default)
+                transp = Transparency.None;
+        }
         sixelEncoder.TransparencyMode = transp;
+
+        // Set background color
+        Sixel.BackgroundColor = Color.White;
 
         if (f >= sixelEncoder.FrameCount)
         {

--- a/example/Program.cs
+++ b/example/Program.cs
@@ -143,8 +143,6 @@ if (IsBinary(infile))
         }
 #if IMAGESHARP4
         var best = Sixel.GetBestFrame(sixelEncoder.Image, null);
-        if (f < 0)
-            f = best;
 #endif
         if (getData)
         {
@@ -156,9 +154,6 @@ if (IsBinary(infile))
             Console.WriteLine(" Num Repeats: " + sixelEncoder.RepeatCount);
             Environment.Exit(sixelEncoder.FrameCount);
         }
-
-        if (!anim && f < 0)
-            f = 0;
 
         if (!string.IsNullOrEmpty(outfile))
         {
@@ -203,8 +198,14 @@ if (IsBinary(infile))
             Environment.Exit(0);
         }
 
-        if (f >= 0)
+        if (!anim)
         {
+#if IMAGESHARP4
+            if (f < 0 && best >= 0)
+                f = best;
+#endif
+            if (f < 0)
+                f = 0;
             Console.Write(sixelEncoder.EncodeFrame(f));
             Environment.Exit(0);
         }

--- a/example/Program.cs
+++ b/example/Program.cs
@@ -215,6 +215,8 @@ if (IsBinary(infile))
         using var ct = new CancellationTokenSource();
         var t1 = sixelEncoder.Animate(animForever ? 0 : 1,
                                       rate > 0 ? rate : 0,
+                                      f < 0 ? 0 : f,
+                                      -1,
                                       ct.Token);
         var t2 = Task.Run(() =>
         {

--- a/example/Program.cs
+++ b/example/Program.cs
@@ -213,8 +213,8 @@ if (IsBinary(infile))
         // Start animation
         Console.WriteLine("Press 'Ctrl+C', 'c' or 'q' to stop.");
         using var ct = new CancellationTokenSource();
+        sixelEncoder.SetFrameDelays(rate > 0 ? rate : 0);
         var t1 = sixelEncoder.Animate(animForever ? 0 : 1,
-                                      rate > 0 ? rate : 0,
                                       f < 0 ? 0 : f,
                                       -1,
                                       ct.Token);

--- a/src/Encoder/CurEncoder.cs
+++ b/src/Encoder/CurEncoder.cs
@@ -24,8 +24,6 @@ public class CurEncoder : SixelEncoder
 
     public CurMetadata Metadata { get; }
 
-    public override bool CanAnimate => false;
-
     /// <summary>
     /// Encode a <see cref="ImageFrame"/> into a Sixel string.
     /// The image frame is choosed automaticaly. (typically the root frame)j
@@ -52,6 +50,12 @@ public class CurEncoder : SixelEncoder
                                  TransparencyMode,
                                  TransparentColor,
                                  BackgroundColor);
+    }
+
+    protected override int GetFrameDelay(int frameIndex)
+    {
+        var delay = FrameDelays[Math.Min(frameIndex, FrameDelays.Length - 1)];
+        return delay <= 0 ? 100 : delay;
     }
 
     /// <summary>

--- a/src/Encoder/CurEncoder.cs
+++ b/src/Encoder/CurEncoder.cs
@@ -52,10 +52,10 @@ public class CurEncoder : SixelEncoder
                                  BackgroundColor);
     }
 
-    protected override int GetFrameDelay(int frameIndex)
+    public override int GetFrameDelay(int frameIndex)
     {
         var delay = FrameDelays[Math.Min(frameIndex, FrameDelays.Length - 1)];
-        return delay <= 0 ? 100 : delay;
+        return delay < 0 ? 100 : delay;
     }
 
     /// <summary>

--- a/src/Encoder/GifEncoder.cs
+++ b/src/Encoder/GifEncoder.cs
@@ -98,9 +98,15 @@ public class GifEncoder : SixelEncoder
                                  bgColor);
     }
 
-    protected override int GetFrameDelay(ImageFrame<Rgba32> frame)
+    protected override int GetFrameDelay(int frameIndex)
     {
-        return frame.Metadata.GetGifMetadata().FrameDelay * 1000 / 100;
+        var delay = FrameDelays[Math.Min(frameIndex, FrameDelays.Length - 1)];
+        if (delay <= 0)
+        {
+            var frame = Image.Frames[frameIndex];
+            return frame.Metadata.GetGifMetadata().FrameDelay * 1000 / 100;
+        }
+        return delay;
     }
 
     protected override void Dispose(bool disposing)

--- a/src/Encoder/GifEncoder.cs
+++ b/src/Encoder/GifEncoder.cs
@@ -98,10 +98,10 @@ public class GifEncoder : SixelEncoder
                                  bgColor);
     }
 
-    protected override int GetFrameDelay(int frameIndex)
+    public override int GetFrameDelay(int frameIndex)
     {
         var delay = FrameDelays[Math.Min(frameIndex, FrameDelays.Length - 1)];
-        if (delay <= 0)
+        if (delay < 0)
         {
             var frame = Image.Frames[frameIndex];
             return frame.Metadata.GetGifMetadata().FrameDelay * 1000 / 100;

--- a/src/Encoder/IcoEncoder.cs
+++ b/src/Encoder/IcoEncoder.cs
@@ -24,8 +24,6 @@ public class IcoEncoder : SixelEncoder
 
     public IcoMetadata Metadata { get; }
 
-    public override bool CanAnimate => false;
-
     /// <summary>
     /// Encode a <see cref="ImageFrame"/> into a Sixel string.
     /// The image frame is choosed automaticaly. (typically the root frame)j
@@ -52,6 +50,12 @@ public class IcoEncoder : SixelEncoder
                                  TransparencyMode,
                                  TransparentColor,
                                  BackgroundColor);
+    }
+
+    protected override int GetFrameDelay(int frameIndex)
+    {
+        var delay = FrameDelays[Math.Min(frameIndex, FrameDelays.Length - 1)];
+        return delay <= 0 ? 100 : delay;
     }
 
     /// <summary>

--- a/src/Encoder/IcoEncoder.cs
+++ b/src/Encoder/IcoEncoder.cs
@@ -52,10 +52,10 @@ public class IcoEncoder : SixelEncoder
                                  BackgroundColor);
     }
 
-    protected override int GetFrameDelay(int frameIndex)
+    public override int GetFrameDelay(int frameIndex)
     {
         var delay = FrameDelays[Math.Min(frameIndex, FrameDelays.Length - 1)];
-        return delay <= 0 ? 100 : delay;
+        return delay < 0 ? 100 : delay;
     }
 
     /// <summary>

--- a/src/Encoder/PngEncoder.cs
+++ b/src/Encoder/PngEncoder.cs
@@ -17,8 +17,14 @@ public class PngEncoder : SixelEncoder
 
     public override uint RepeatCount => Metadata.RepeatCount;
 
-    protected override int GetFrameDelay(ImageFrame<Rgba32> frame)
+    protected override int GetFrameDelay(int frameIndex)
     {
-        return (int)(frame.Metadata.GetPngMetadata().FrameDelay.ToDouble() * 1000);
+        var delay = FrameDelays[Math.Min(frameIndex, FrameDelays.Length - 1)];
+        if (delay <= 0)
+        {
+            var frame = Image.Frames[frameIndex];
+            return (int)(frame.Metadata.GetPngMetadata().FrameDelay.ToDouble() * 1000);
+        }
+        return delay;
     }
 }

--- a/src/Encoder/PngEncoder.cs
+++ b/src/Encoder/PngEncoder.cs
@@ -17,10 +17,10 @@ public class PngEncoder : SixelEncoder
 
     public override uint RepeatCount => Metadata.RepeatCount;
 
-    protected override int GetFrameDelay(int frameIndex)
+    public override int GetFrameDelay(int frameIndex)
     {
         var delay = FrameDelays[Math.Min(frameIndex, FrameDelays.Length - 1)];
-        if (delay <= 0)
+        if (delay < 0)
         {
             var frame = Image.Frames[frameIndex];
             return (int)(frame.Metadata.GetPngMetadata().FrameDelay.ToDouble() * 1000);

--- a/src/Encoder/SixelEncoder.cs
+++ b/src/Encoder/SixelEncoder.cs
@@ -313,6 +313,8 @@ public class SixelEncoder(Image<Rgba32> img, string? format) : IDisposable
             throw new NotSupportedException($"This format does not support animation: {Format}");
         }
 
+        bool isOpaque = TransparencyMode == Transparency.None;
+
         var cursorSize = Sixel.GetCellSize();
         int lines = (int)Math.Ceiling((double)Image.Height / cursorSize.Height);
         // Allocate rows for the image height
@@ -328,8 +330,17 @@ public class SixelEncoder(Image<Rgba32> img, string? format) : IDisposable
                                                                 endFrame,
                                                                 cancellationToken))
             {
-                // Restore the cursor position and then output sixel string
-                Console.WriteLine($"{Sixel.ESC}[u{Sixel.ESC}[0J{sixelString}");
+                if (isOpaque)
+                {
+                    // Restore the cursor position and then output sixel string
+                    Console.WriteLine($"{Sixel.ESC}[u{sixelString}");
+                }
+                else
+                {
+                    // Restore the cursor position and erase from cursor until end of screen,
+                    // and then output sixel string
+                    Console.WriteLine($"{Sixel.ESC}[u{Sixel.ESC}[0J{sixelString}");
+                }
             }
         }
         catch (TaskCanceledException)

--- a/src/Encoder/TiffEncoder.cs
+++ b/src/Encoder/TiffEncoder.cs
@@ -13,5 +13,5 @@ public class TiffEncoder : SixelEncoder
 
     public TiffMetadata Metadata { get; }
 
-    public override bool CanAnimate => false;
+    public override bool CanAnimate => true;
 }

--- a/src/Encoder/WebpEncoder.cs
+++ b/src/Encoder/WebpEncoder.cs
@@ -16,10 +16,10 @@ public class WebpEncoder : SixelEncoder
 
     public override uint RepeatCount => Metadata.RepeatCount;
 
-    protected override int GetFrameDelay(int frameIndex)
+    public override int GetFrameDelay(int frameIndex)
     {
         var delay = FrameDelays[Math.Min(frameIndex, FrameDelays.Length - 1)];
-        if (delay <= 0)
+        if (delay < 0)
         {
             var frame = Image.Frames[frameIndex];
             return (int)frame.Metadata.GetWebpMetadata().FrameDelay;

--- a/src/Encoder/WebpEncoder.cs
+++ b/src/Encoder/WebpEncoder.cs
@@ -16,8 +16,14 @@ public class WebpEncoder : SixelEncoder
 
     public override uint RepeatCount => Metadata.RepeatCount;
 
-    protected override int GetFrameDelay(ImageFrame<Rgba32> frame)
+    protected override int GetFrameDelay(int frameIndex)
     {
-        return (int)frame.Metadata.GetWebpMetadata().FrameDelay;
+        var delay = FrameDelays[Math.Min(frameIndex, FrameDelays.Length - 1)];
+        if (delay <= 0)
+        {
+            var frame = Image.Frames[frameIndex];
+            return (int)frame.Metadata.GetWebpMetadata().FrameDelay;
+        }
+        return delay;
     }
 }

--- a/src/Sixel.Encode.cs
+++ b/src/Sixel.Encode.cs
@@ -275,8 +275,8 @@ public static partial class Sixel
                     if (idx < 0)
                         continue;
                     if (colorPalette[idx].A == 0)
-                        cset[idx] = false;
-                    else if (transp == Transparency.TopLeft && idx == 0)
+                        cset[idx] = transp == Transparency.None;
+                    else if (transp == Transparency.TopLeft && rgba.Equals(frame[0, 0]))
                         cset[idx] = false;
                     else if (transp == Transparency.Background && bg is not null && bg.Equals(rgba))
                         cset[idx] = false;

--- a/src/Sixel.Supported.cs
+++ b/src/Sixel.Supported.cs
@@ -112,6 +112,12 @@ public static partial class Sixel
     }
 
     /// <summary>
+    /// Background color.
+    /// The transparent color is replaced by this color when <see cref="Transparency"/> is <c>None</c>
+    /// </summary>
+    public static Color BackgroundColor { get; set; } = Color.White;
+
+    /// <summary>
     /// Get the response to an ANSI control sequence.
     /// <returns>string response</returns>
     /// </summary>

--- a/src/SixelColor.cs
+++ b/src/SixelColor.cs
@@ -98,8 +98,11 @@ public record struct SixelColor
                                         Color? bg = null)
     {
         var alpha = (byte)Math.Round(rgba.A * 100.0 / 0xFF);
-        if (alpha == 0)
-            return new(0, 0, 0, 0);
+        if (transp == Transparency.None && alpha == 0)
+        {
+            // xxx: should be use <paramref name="tc"/> or <paramref name="bg"/> if available ?
+            return FromColor(Sixel.BackgroundColor);
+        }
 #if IMAGESHARP4 // ImageSharp v4.0
         else if (tc is not null && tc == Color.FromScaledVector(new Vector4(rgba.R, rgba.G, rgba.B, 0)))
             return new(0, 0, 0, alpha);


### PR DESCRIPTION
- #12

Imporve animation and fix bugs:

- Enable to animation for ICO/CUR/TIFF
- Enable to specify the start (and end) frame of the animation
- Replace the color with the background color  when `Transparency` is `None` and that is transparent,  and fill with that color.
- When opaque mode (`Transparency` is `None'), omit erasing screen for avoiding flicker.