### PR TITLE
Synchronized output support

### DIFF
--- a/example/Program.cs
+++ b/example/Program.cs
@@ -349,8 +349,12 @@ static void PrintUsage()
         var windowCharSize = Sixel.GetWindowCharSize();
         var windowPixelSize = Sixel.GetWindowPixelSize();
 
-        Console.WriteLine($"Sixel is supported! [Cell Size:{cellSize.Width}x{cellSize.Height}; " +
-            $"Current Window:{windowPixelSize.Width}x{windowPixelSize.Height}px, {windowCharSize.Width}x{windowCharSize.Height}ch]");
+        Console.WriteLine($"Sixel is supported!");
+        Console.WriteLine($"Background:#{Sixel.BackgroundColor}; " +
+            $"Sync Output:{Sixel.IsSyncSupported()}; " +
+            $"Cell Size:{cellSize.Width}x{cellSize.Height}; " +
+            $"Current Window:{windowPixelSize.Width}x{windowPixelSize.Height}px, " +
+            $"{windowCharSize.Width}x{windowCharSize.Height}ch");
     }
     else
         Console.WriteLine("If you see colored bands above, your terminal supports Sixel.");

--- a/src/Encoder/SixelEncoder.cs
+++ b/src/Encoder/SixelEncoder.cs
@@ -329,6 +329,12 @@ public class SixelEncoder(Image<Rgba32> img, string? format) : IDisposable
         Console.Write($"{Sixel.ESC}[{lines}A");
         // Save the cursor position
         Console.Write($"{Sixel.ESC}[s");
+        string beginSync = "", endSync = "";
+        if (Sixel.IsSyncSupported())
+        {
+            beginSync = Sixel.SyncBegin;
+            endSync = Sixel.SyncEnd + Sixel.ESC + Sixel.End;
+        }
         try
         {
             await foreach (var sixelString in EncodeFramesAsync(overwriteRepeat,
@@ -344,8 +350,8 @@ public class SixelEncoder(Image<Rgba32> img, string? format) : IDisposable
                 else
                 {
                     // Restore the cursor position and erase from cursor until end of screen,
-                    // and then output sixel string
-                    Console.WriteLine($"{Sixel.ESC}[u{Sixel.ESC}[0J{sixelString}");
+                    // and then output sixel string; do the erase and draw in one batch update if possible
+                    Console.WriteLine($"{beginSync}{Sixel.ESC}[u{Sixel.ESC}[0J{sixelString}{endSync}");
                 }
             }
         }

--- a/src/Sixel.Encode.cs
+++ b/src/Sixel.Encode.cs
@@ -19,6 +19,10 @@ public static partial class Sixel
 {
     public const char ESC = '\x1b';
     public const string SixelStart = "P7;1;q\"1;1";
+    public const string SyncBegin = $"\x1b[?2026h";
+    public const string SyncEnd = $"\x1b[?2026l";
+    public const string OpaqueStart = "P7;0;q\"1;1";
+    public const string TranspStart = "P7;1;q\"1;1";
     public const string End = "\\";
 
     private const byte specialChNr = 0x6d;

--- a/src/Sixel.Supported.cs
+++ b/src/Sixel.Supported.cs
@@ -10,6 +10,7 @@ public static partial class Sixel
     private static Size? CellSize;
 
     private const string CSI_DEVICE_ATTRIBUTES = "[c";
+    private const string CSI_SYNC_OUTPUT = "[?2026$p";
     private const string CSI_CELL_SIZE = "[16t";
     private const string CSI_WINDOW_PIXSIZE = "[14t";
     private const string CSI_WINDOW_CHARSIZE = "[18t";
@@ -28,6 +29,21 @@ public static partial class Sixel
 
         return response.Contains(";4;", StringComparison.Ordinal)
             || response.EndsWith(";4", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Check whether current terminal support synchronized output
+    /// <returns>bool</returns>
+    /// </summary>
+    public static bool IsSyncSupported()
+    {
+
+        // Should get something like: ^[[?2026;1$yc
+        // The "1" indicates synchronized output support (may receive 0 in its place, or nothing at all)
+        DebugPrint($"IsSyncSupported: ^[{CSI_SYNC_OUTPUT} => ", ConsoleColor.DarkGray);
+        var response = GetCtrlSeqResponse(CSI_SYNC_OUTPUT);
+
+        return !(response == default || response.Contains("2026;0$", StringComparison.Ordinal));
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #15 

No more flicker during animation!

For Windows Terminal support, this currently requires a [Canary nightly build](https://aka.ms/terminal-canary-installer).

The only issue that I see right now is that the cursor dances a bit (see video).  I'm sure it's something simple; I haven't looked into it yet.  I'll mark this as draft until that's fixed; but perhaps it can be moot since the cursor flickering has always been an issue: should we just turn off the cursor when animating and turn it back on again after?
Hide: CSI ?25l
Show: CSI ?25h.

https://github.com/user-attachments/assets/49b1fd0e-5418-4303-b182-02d370c7faa8
