### PR TITLE
Skip quantization on Png image

### DIFF
--- a/src/Encoder/PngEncoder.cs
+++ b/src/Encoder/PngEncoder.cs
@@ -9,8 +9,19 @@ public class PngEncoder : SixelEncoder
     public PngEncoder(Image<Rgba32> img) : base(img, "PNG")
     {
         Metadata = img.Metadata.GetPngMetadata();
-        if (Metadata.ColorType == PngColorType.Palette)
-            TransparentColor = Metadata.TransparentColor?.ToPixel<Rgba32>();
+        switch (Metadata.ColorType)
+        {
+            case PngColorType.Palette:
+                TransparentColor = Metadata.TransparentColor?.ToPixel<Rgba32>();
+                Quantized = true;
+                break;
+            case PngColorType.Rgb:
+                Quantized = true;
+                break;
+            case PngColorType.Grayscale:
+                Quantized = true;
+                break;
+        }
     }
 
     public PngMetadata Metadata { get; }


### PR DESCRIPTION
Skip quantization when the color type of png is Palette, Rgb or Grayscale.
It will improve performance.